### PR TITLE
Relations

### DIFF
--- a/app/models/item_topping.rb
+++ b/app/models/item_topping.rb
@@ -1,2 +1,8 @@
 class ItemTopping < ApplicationRecord
+  # This is a join table which will hold the ids of a corresponding item, and a topping id
+  # and will be used to determine the available toppings for a particular item.
+
+  # Relationships
+  belongs_to :item
+  belongs_to :topping
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,8 +3,9 @@ class Order < ApplicationRecord
   has_many :order_items, dependent: :destroy
   has_many :order_item_toppings, through: :order_items
 
-  # Accept nested attributes for order_items, item_toppings?
+  # Accept nested attributes for order_items
   accepts_nested_attributes_for :order_items
+
   # Scopes
   scope :best_customers, -> { order(total: :desc).limit(5) }
 

--- a/app/models/topping.rb
+++ b/app/models/topping.rb
@@ -1,6 +1,6 @@
 class Topping < ApplicationRecord
   # Relationships
-  has_many :items
+  has_many :item_toppings
 
   # Scopes
 

--- a/db/migrate/20220908121402_remove_foreign_keys_from_items_order_id_toppings_item_id.rb
+++ b/db/migrate/20220908121402_remove_foreign_keys_from_items_order_id_toppings_item_id.rb
@@ -1,0 +1,9 @@
+class RemoveForeignKeysFromItemsOrderIdToppingsItemId < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :items, :order_id
+    remove_index :items, column: :order_id, if_exists: true
+
+    remove_column :toppings, :item_id
+    remove_index :toppings, column: :item_id, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_27_222140) do
+ActiveRecord::Schema.define(version: 2022_09_08_121402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,10 +28,8 @@ ActiveRecord::Schema.define(version: 2022_08_27_222140) do
     t.string "name"
     t.decimal "price", precision: 8, scale: 2, default: "0.0"
     t.integer "item_type"
-    t.bigint "order_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["order_id"], name: "index_items_on_order_id"
   end
 
   create_table "order_item_toppings", force: :cascade do |t|
@@ -63,10 +61,8 @@ ActiveRecord::Schema.define(version: 2022_08_27_222140) do
   create_table "toppings", force: :cascade do |t|
     t.string "name", null: false
     t.float "price", default: 0.0, null: false
-    t.bigint "item_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["item_id"], name: "index_toppings_on_item_id"
   end
 
 end


### PR DESCRIPTION
Remove unnecessary columns from base model tables and correlating indexes
Rely on join tables to connect model objects via rails relationship macros