### PR TITLE
Update schema to match price column in other tables

### DIFF
--- a/db/migrate/20220914023250_change_price_total_toppings_orders_float_to_decimal.rb
+++ b/db/migrate/20220914023250_change_price_total_toppings_orders_float_to_decimal.rb
@@ -1,0 +1,6 @@
+class ChangePriceTotalToppingsOrdersFloatToDecimal < ActiveRecord::Migration[6.1]
+  def change
+    change_column :orders, :total, :decimal, precision: 8, scale: 2, default: 0.00
+    change_column :toppings, :price, :decimal, precision: 8, scale: 2, default: 0.00
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -56,7 +56,6 @@ ActiveRecord::Schema.define(version: 2022_09_14_023250) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "completed", default: false
-    t.boolean "completed", default: false
     t.index ["total"], name: "index_orders_on_total"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_08_121402) do
+ActiveRecord::Schema.define(version: 2022_09_14_023250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,16 +51,17 @@ ActiveRecord::Schema.define(version: 2022_09_08_121402) do
   end
 
   create_table "orders", force: :cascade do |t|
-    t.float "total"
+    t.decimal "total", precision: 8, scale: 2, default: "0.0"
     t.string "cust_name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "completed", default: false
     t.index ["total"], name: "index_orders_on_total"
   end
 
   create_table "toppings", force: :cascade do |t|
     t.string "name", null: false
-    t.float "price", default: 0.0, null: false
+    t.decimal "price", precision: 8, scale: 2, default: "0.0", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
Swap orders.total and toppings.price to use t.decimal column_type in rails for use with ActiveSupport number helpers